### PR TITLE
Fix terminal resize, tab layout and some cleanup

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.scss
@@ -1,11 +1,9 @@
 .co-cloud-shell-tab {
-  position: fixed;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
-  padding-bottom: var(--pf-global--spacer--xl);
   background-color: var(--pf-global--Color--dark-100);
   &__header {
     flex-shrink: 0;

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
@@ -1,7 +1,7 @@
 .odc-cloudshell-terminal {
   &__container {
-    background-color: var(--pf-global--palette--black-1000);
-    color: var(--pf-global--primary-color--100);
+    background-color: var(--pf-global--BackgroundColor--dark-100);
+    color: var(--pf-global--Color--light-100);
     width: 100%;
     height: 100%;
   }

--- a/frontend/packages/console-app/src/components/cloud-shell/Terminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/Terminal.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
-import Measure from 'react-measure';
 import { Terminal as XTerminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 
 XTerminal.applyAddon(fit);
+
+const terminalOptions = {
+  fontFamily: 'monospace',
+  fontSize: 16,
+  cursorBlink: false,
+  cols: 80,
+  rows: 25,
+  padding: 4,
+};
 
 type TerminalProps = {
   onData: (data: string) => void;
@@ -14,61 +22,49 @@ class Terminal extends React.Component<TerminalProps> {
 
   private terminal;
 
+  private resizeObserver;
+
   constructor(props) {
     super(props);
-    const options = {
-      fontFamily: 'monospace',
-      fontSize: 16,
-      cursorBlink: false,
-      cols: 80,
-      rows: 25,
-      padding: 4,
-    };
     this.terminalRef = React.createRef<HTMLDivElement>();
-    this.terminal = new XTerminal(options);
+    this.terminal = new XTerminal(terminalOptions);
     this.terminal.on('data', this.props.onData);
+  }
+
+  componentDidMount() {
+    this.terminal.open(this.terminalRef.current);
+    this.resizeObserver = new ResizeObserver(() => {
+      window.requestAnimationFrame(() => this.terminal.fit());
+    });
+    this.resizeObserver.observe(this.terminalRef.current);
+    this.focus();
+  }
+
+  componentWillUnmount() {
+    this.terminal.destroy();
+    this.resizeObserver.disconnect();
   }
 
   focus() {
     this.terminal && this.terminal.focus();
   }
 
+  reset() {
+    this.terminal.reset();
+    this.terminal.clear();
+    this.terminal.setOption('disableStdin', false);
+  }
+
   onDataReceived(data) {
     this.terminal && this.terminal.write(data);
   }
 
-  reset() {
-    const { terminal } = this;
-
-    terminal.reset();
-    terminal.clear();
-    terminal.setOption('disableStdin', false);
-  }
-
   onConnectionClosed = (reason) => {
-    const { terminal } = this;
-    terminal.write(`\x1b[31m${reason || 'disconnected'}\x1b[m\r\n`);
-    terminal.cursorHidden = true;
-    terminal.setOption('disableStdin', true);
-    terminal.refresh(terminal.y, terminal.y);
+    this.terminal.write(`\x1b[31m${reason || 'disconnected'}\x1b[m\r\n`);
+    this.terminal.cursorHidden = true;
+    this.terminal.setOption('disableStdin', true);
+    this.terminal.refresh(this.terminal.y, this.terminal.y);
   };
-
-  componentDidMount() {
-    this.terminal.open(this.terminalRef.current);
-    this.focus();
-  }
-
-  componentWillUnmount() {
-    this.terminal && this.terminal.destroy();
-  }
-
-  resize() {
-    try {
-      this.terminal.fit();
-    } finally {
-      // do nothing
-    }
-  }
 
   render() {
     return <div ref={this.terminalRef} style={{ width: '100%', height: '100%' }} />;

--- a/frontend/packages/console-app/src/components/cloud-shell/TerminalLoadingBox.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/TerminalLoadingBox.tsx
@@ -1,14 +1,8 @@
 import * as React from 'react';
 import { LoadingBox } from '@console/internal/components/utils/status-box';
-import './CloudShellTerminal.scss';
 
-type TerminalLoadingBoxProps = {
-  message?: string;
-};
-const TerminalLoadingBox: React.FC<TerminalLoadingBoxProps> = ({ message }) => (
-  <div className="odc-cloudshell-terminal__container">
-    <LoadingBox message={message || 'Connecting to your OpenShift command line terminal ...'} />
-  </div>
+const TerminalLoadingBox: React.FC = () => (
+  <LoadingBox message="Connecting to your OpenShift command line terminal ..." />
 );
 
 export default TerminalLoadingBox;

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { LoadingBox } from '@console/internal/components/utils/status-box';
 import { InternalCloudShellTerminal } from '../CloudShellTerminal';
@@ -12,7 +12,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 describe('CloudShellTerminal', () => {
   it('should display loading box', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false]);
-    const wrapper = shallow(<InternalCloudShellTerminal username="user" />);
+    const wrapper = mount(<InternalCloudShellTerminal username="user" />);
     expect(wrapper.find(LoadingBox)).toHaveLength(1);
   });
 

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -2,8 +2,6 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getRandomChars } from '@console/shared';
 import { coFetchJSON } from '@console/internal/co-fetch';
 
-export type InitResponseObject = { pod: string; container: string; cmd: string[] };
-
 type environment = {
   value: string;
   name: string;
@@ -37,6 +35,8 @@ export type CloudShellResource = K8sResourceKind & {
     devfile?: Devfile;
   };
 };
+
+export type TerminalInitData = { pod: string; container: string; cmd: string[] };
 
 export const CLOUD_SHELL_LABEL = 'console.openshift.io/cloudshell';
 export const CLOUD_SHELL_USER_ANNOTATION = 'console.openshift.io/cloudshell-user';
@@ -95,12 +95,13 @@ export const initTerminal = (
   username: string,
   workspaceName: string,
   workspaceNamespace: string,
-): Promise<InitResponseObject> => {
-  const consumeUrl = `/api/terminal/${workspaceNamespace}/${workspaceName}/exec/init`;
-  return coFetchJSON.post(consumeUrl, {
+): Promise<TerminalInitData> => {
+  const url = `/api/terminal/${workspaceNamespace}/${workspaceName}/exec/init`;
+  const payload = {
     kubeconfig: {
       username,
       namespace: workspaceNamespace,
     },
-  });
+  };
+  return coFetchJSON.post(url, payload);
 };

--- a/frontend/packages/console-app/src/types/ResizeObserver.d.ts
+++ b/frontend/packages/console-app/src/types/ResizeObserver.d.ts
@@ -1,0 +1,239 @@
+/**
+ * The **ResizeObserver** interface reports changes to the dimensions of an
+ * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element)'s content
+ * or border box, or the bounding box of an
+ * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement).
+ *
+ * > **Note**: The content box is the box in which content can be placed,
+ * > meaning the border box minus the padding and border width. The border box
+ * > encompasses the content, padding, and border. See
+ * > [The box model](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model)
+ * > for further explanation.
+ *
+ * `ResizeObserver` avoids infinite callback loops and cyclic dependencies that
+ * are often created when resizing via a callback function. It does this by only
+ * processing elements deeper in the DOM in subsequent frames. Implementations
+ * should, if they follow the specification, invoke resize events before paint
+ * and after layout.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+ */
+declare class ResizeObserver {
+  /**
+   * The **ResizeObserver** constructor creates a new `ResizeObserver` object,
+   * which can be used to report changes to the content or border box of an
+   * `Element` or the bounding box of an `SVGElement`.
+   *
+   * @example
+   * var ResizeObserver = new ResizeObserver(callback)
+   *
+   * @param callback
+   * The function called whenever an observed resize occurs. The function is
+   * called with two parameters:
+   * * **entries**
+   *   An array of
+   *   [ResizeObserverEntry](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry)
+   *   objects that can be used to access the new dimensions of the element
+   *   after each change.
+   * * **observer**
+   *   A reference to the `ResizeObserver` itself, so it will definitely be
+   *   accessible from inside the callback, should you need it. This could be
+   *   used for example to automatically unobserve the observer when a certain
+   *   condition is reached, but you can omit it if you don't need it.
+   *
+   * The callback will generally follow a pattern along the lines of:
+   * ```js
+   * function(entries, observer) {
+   *   for (let entry of entries) {
+   *     // Do something to each entry
+   *     // and possibly something to the observer itself
+   *   }
+   * }
+   * ```
+   *
+   * The following snippet is taken from the
+   * [resize-observer-text.html](https://mdn.github.io/dom-examples/resize-observer/resize-observer-text.html)
+   * ([see source](https://github.com/mdn/dom-examples/blob/master/resize-observer/resize-observer-text.html))
+   * example:
+   * @example
+   * const resizeObserver = new ResizeObserver(entries => {
+   *   for (let entry of entries) {
+   *     if(entry.contentBoxSize) {
+   *       h1Elem.style.fontSize = Math.max(1.5, entry.contentBoxSize.inlineSize/200) + 'rem';
+   *       pElem.style.fontSize = Math.max(1, entry.contentBoxSize.inlineSize/600) + 'rem';
+   *     } else {
+   *       h1Elem.style.fontSize = Math.max(1.5, entry.contentRect.width/200) + 'rem';
+   *       pElem.style.fontSize = Math.max(1, entry.contentRect.width/600) + 'rem';
+   *     }
+   *   }
+   * });
+   *
+   * resizeObserver.observe(divElem);
+   */
+  constructor(callback: ResizeObserverCallback);
+
+  /**
+   * The **disconnect()** method of the
+   * [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+   * interface unobserves all observed
+   * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or
+   * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)
+   * targets.
+   */
+  disconnect: () => void;
+
+  /**
+   * The `observe()` method of the
+   * [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+   * interface starts observing the specified
+   * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or
+   * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement).
+   *
+   * @example
+   * resizeObserver.observe(target, options);
+   *
+   * @param target
+   * A reference to an
+   * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or
+   * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)
+   * to be observed.
+   *
+   * @param options
+   * An options object allowing you to set options for the observation.
+   * Currently this only has one possible option that can be set.
+   */
+  observe: (target: Element, options?: ResizeObserverObserveOptions) => void;
+
+  /**
+   * The **unobserve()** method of the
+   * [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+   * interface ends the observing of a specified
+   * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or
+   * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement).
+   */
+  unobserve: (target: Element) => void;
+}
+
+interface ResizeObserverObserveOptions {
+  /**
+   * Sets which box model the observer will observe changes to. Possible values
+   * are `content-box` (the default), and `border-box`.
+   *
+   * @default "content-box"
+   */
+  box?: 'content-box' | 'border-box';
+}
+
+/**
+ * The function called whenever an observed resize occurs. The function is
+ * called with two parameters:
+ *
+ * @param entries
+ * An array of
+ * [ResizeObserverEntry](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry)
+ * objects that can be used to access the new dimensions of the element after
+ * each change.
+ *
+ * @param observer
+ * A reference to the `ResizeObserver` itself, so it will definitely be
+ * accessible from inside the callback, should you need it. This could be used
+ * for example to automatically unobserve the observer when a certain condition
+ * is reached, but you can omit it if you don't need it.
+ *
+ * The callback will generally follow a pattern along the lines of:
+ * @example
+ * function(entries, observer) {
+ *   for (let entry of entries) {
+ *     // Do something to each entry
+ *     // and possibly something to the observer itself
+ *   }
+ * }
+ *
+ * @example
+ * const resizeObserver = new ResizeObserver(entries => {
+ *   for (let entry of entries) {
+ *     if(entry.contentBoxSize) {
+ *       h1Elem.style.fontSize = Math.max(1.5, entry.contentBoxSize.inlineSize/200) + 'rem';
+ *       pElem.style.fontSize = Math.max(1, entry.contentBoxSize.inlineSize/600) + 'rem';
+ *     } else {
+ *       h1Elem.style.fontSize = Math.max(1.5, entry.contentRect.width/200) + 'rem';
+ *       pElem.style.fontSize = Math.max(1, entry.contentRect.width/600) + 'rem';
+ *     }
+ *   }
+ * });
+ *
+ * resizeObserver.observe(divElem);
+ */
+type ResizeObserverCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void;
+
+/**
+ * The **ResizeObserverEntry** interface represents the object passed to the
+ * [ResizeObserver()](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver)
+ * constructor's callback function, which allows you to access the new
+ * dimensions of the
+ * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or
+ * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)
+ * being observed.
+ */
+interface ResizeObserverEntry {
+  /**
+   * An object containing the new border box size of the observed element when
+   * the callback is run.
+   */
+  readonly borderBoxSize: ResizeObserverEntryBoxSize;
+
+  /**
+   * An object containing the new content box size of the observed element when
+   * the callback is run.
+   */
+  readonly contentBoxSize: ResizeObserverEntryBoxSize;
+
+  /**
+   * A [DOMRectReadOnly](https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly)
+   * object containing the new size of the observed element when the callback is
+   * run. Note that this is better supported than the above two properties, but
+   * it is left over from an earlier implementation of the Resize Observer API,
+   * is still included in the spec for web compat reasons, and may be deprecated
+   * in future versions.
+   */
+  // node_modules/typescript/lib/lib.dom.d.ts
+  readonly contentRect: DOMRectReadOnly;
+
+  /**
+   * A reference to the
+   * [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) or
+   * [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)
+   * being observed.
+   */
+  readonly target: Element;
+}
+
+/**
+ * The **borderBoxSize** read-only property of the
+ * [ResizeObserverEntry](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry)
+ * interface returns an object containing the new border box size of the
+ * observed element when the callback is run.
+ */
+interface ResizeObserverEntryBoxSize {
+  /**
+   * The length of the observed element's border box in the block dimension. For
+   * boxes with a horizontal
+   * [writing-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode),
+   * this is the vertical dimension, or height; if the writing-mode is vertical,
+   * this is the horizontal dimension, or width.
+   */
+  blockSize: number;
+
+  /**
+   * The length of the observed element's border box in the inline dimension.
+   * For boxes with a horizontal
+   * [writing-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode),
+   * this is the horizontal dimension, or width; if the writing-mode is
+   * vertical, this is the vertical dimension, or height.
+   */
+  inlineSize: number;
+}
+
+interface Window {
+  ResizeObserver: typeof ResizeObserver;
+}


### PR DESCRIPTION
This PR -
- Fixes issue with terminal auto resize using `ResizeObserver`. 
- Fixes logic for making `initTerminal` API call.
- Fixes failing unit tests.
- Updates the loading component and uses same message for all loading states.
- Adds a type declaration for `ResizeObserver`.
- Updates some css styles.
- Fixes issue with tab layout in flex mode.
- Other code cleanups.